### PR TITLE
Package index generation now works on Windows

### DIFF
--- a/javasphinx/apidoc.py
+++ b/javasphinx/apidoc.py
@@ -46,7 +46,9 @@ def write_toc(packages, opts):
     packages = list(packages)
     packages.sort()
     for package in packages:
-        toc.add_content(os.path.join(package.replace('.', os.sep), 'package-index') + '\n')
+        index_path = os.path.join(package.replace('.', os.sep), 'package-index') + '\n'
+        index_path = index_path.replace("\\", "/")
+        toc.add_content(index_path)
 
     filename = 'packages.' + opts.suffix
     fullpath = os.path.join(opts.destdir, filename)


### PR DESCRIPTION
Hi there,

Previously, the path to the leaf level index file was used in indexes further up the tree. On windows these had backslashes which confuse sphinx. My solution was to replace them with sphinx friendly forward slashes. On nix the replace should be a no-op.

Eg:
Run javasphinx on source in com/test/foo/wibble and com/test/foo/blibble.
The top level package index document would look like:

com\test\foo\wibble\package-index
com\test\foo\blibble\package-index

Now it looks like:

com/test/foo/wibble/package-index
com/test/foo/blibble/package-index

Thought I'd open a pull requested in case you were interested.

Thanks
