### PR TITLE
Compiler broken with javalang-0.9.5

### DIFF
--- a/javasphinx/compiler.py
+++ b/javasphinx/compiler.py
@@ -39,8 +39,8 @@ class JavadocRestCompiler(object):
             output.add(self.__html_to_rst(doc.description))
             output.clear()
 
-        if doc.author:
-            output.add_line(':author: %s' % (self.__html_to_rst(doc.author),))
+        if doc.authors:
+            output.add_line(':author: %s' % (self.__html_to_rst(', '.join(doc.authors)),))
 
         for name, value in doc.params:
             output.add_line(':param %s: %s' % (name, self.__html_to_rst(value)))


### PR DESCRIPTION
The change https://github.com/c2nes/javalang/commit/87be12e517818c724b7b3e3804717ac7f0d6e9c8#diff-6cec187ada2119ebad1cda50e2d2a573
breaks javasphinx, unless something like this
change is done
