### PR TITLE
make get_javadoc_ref perform according to docs

### DIFF
--- a/javasphinx/extdoc.py
+++ b/javasphinx/extdoc.py
@@ -35,6 +35,7 @@ def get_javadoc_ref(app, rawtext, text):
     for pkg, (baseurl, ext_type) in javadoc_url_map.items():
         if text.startswith(pkg + '.') and len(pkg) > len(package):
             source = baseurl, ext_type
+            package = pkg
 
     if not source:
         return None


### PR DESCRIPTION
Store current match so that we do longest match
instead of last match as currently.

This was impeding match of "javax.servlet" in a different
place than, say, "javax.sql".
