### PR TITLE
Add option --no-member-headers.

### DIFF
--- a/javasphinx/apidoc.py
+++ b/javasphinx/apidoc.py
@@ -178,10 +178,10 @@ def generate_from_source_file(doc_compiler, source_file, cache_dir):
 
     return documents
 
-def generate_documents(source_files, cache_dir, verbose):
+def generate_documents(source_files, cache_dir, verbose, member_headers):
     documents = {}
     sources = {}
-    doc_compiler = compiler.JavadocRestCompiler()
+    doc_compiler = compiler.JavadocRestCompiler(None, member_headers)
 
     for source_file in source_files:
         if verbose:
@@ -245,6 +245,8 @@ Note: By default this script will not overwrite already created files.""")
                       help='Overwrite new and changed files', default=False)
     parser.add_option('-T', '--no-toc', action='store_true', dest='notoc',
                       help='Don\'t create a table of contents file')
+    parser.add_option('--no-member-headers', action='store_false', default=True, dest='member_headers',
+                      help='Don\'t generate headers for class members')
     parser.add_option('-s', '--suffix', action='store', dest='suffix',
                       help='file suffix (default: rst)', default='rst')
     parser.add_option('-I', '--include', action='append', dest='includes',
@@ -285,7 +287,8 @@ Note: By default this script will not overwrite already created files.""")
     for input_path in input_paths:
         source_files.extend(find_source_files(input_path, excludes))
 
-    packages, documents, sources = generate_documents(source_files, opts.cache_dir, opts.verbose)
+    packages, documents, sources = generate_documents(source_files, opts.cache_dir, opts.verbose,
+                                                      opts.member_headers)
 
     write_documents(documents, sources, opts)
 

--- a/javasphinx/compiler.py
+++ b/javasphinx/compiler.py
@@ -12,7 +12,7 @@ class JavadocRestCompiler(object):
     """ Javadoc to ReST compiler. Builds ReST documentation from a Java syntax
     tree. """
 
-    def __init__(self, filter=None):
+    def __init__(self, filter=None, member_headers=True):
         if filter:
             self.filter = filter
         else:
@@ -20,6 +20,8 @@ class JavadocRestCompiler(object):
             self.filter = lambda node: isinstance(node, javalang.tree.Declaration) and 'private' not in node.modifiers
 
         self.converter = htmlrst.Converter()
+
+        self.member_headers = member_headers
 
     def __html_to_rst(self, s):
         return self.converter.convert(s)
@@ -214,7 +216,8 @@ class JavadocRestCompiler(object):
 
             document.add_heading('Enum Constants')
             for enum_constant in enum_constants:
-                document.add_heading(enum_constant.name, '^')
+                if self.member_headers:
+                    document.add_heading(enum_constant.name, '^')
                 c = self.compile_enum_constant(name, enum_constant)
                 c.add_option('outertype', name)
                 document.add_object(c)
@@ -224,7 +227,8 @@ class JavadocRestCompiler(object):
             document.add_heading('Fields', '-')
             fields.sort(key=lambda f: f.declarators[0].name)
             for field in fields:
-                document.add_heading(field.declarators[0].name, '^')
+                if self.member_headers:
+                    document.add_heading(field.declarators[0].name, '^')
                 f = self.compile_field(field)
                 f.add_option('outertype', name)
                 document.add_object(f)
@@ -234,7 +238,8 @@ class JavadocRestCompiler(object):
             document.add_heading('Constructors', '-')
             constructors.sort(key=lambda c: c.name)
             for constructor in constructors:
-                document.add_heading(constructor.name, '^')
+                if self.member_headers:
+                    document.add_heading(constructor.name, '^')
                 c = self.compile_constructor(constructor)
                 c.add_option('outertype', name)
                 document.add_object(c)
@@ -244,7 +249,8 @@ class JavadocRestCompiler(object):
             document.add_heading('Methods', '-')
             methods.sort(key=lambda m: m.name)
             for method in methods:
-                document.add_heading(method.name, '^')
+                if self.member_headers:
+                    document.add_heading(method.name, '^')
                 m = self.compile_method(method)
                 m.add_option('outertype', name)
                 document.add_object(m)


### PR DESCRIPTION
This option can be used to skip generation of headers for class members.

As suggested in https://github.com/bronto/javasphinx/pull/23#discussion-diff-9850524, `member_headers` is now used as the variable name to avoid negation.
