### PR TITLE
Fix non-capitalized final part bug

### DIFF
--- a/javasphinx/compiler.py
+++ b/javasphinx/compiler.py
@@ -281,8 +281,7 @@ class JavadocRestCompiler(object):
             # If the import's final part wasn't capitalized,
             # append it to the class parts anyway so sphinx doesn't complain.
             if cls_parts == []:
-                parts = imp.path.split('.')
-                cls_parts.append(parts[-1])
+                cls_parts.append(package_parts.pop())
 
             package = '.'.join(package_parts)
             cls = '.'.join(cls_parts)


### PR DESCRIPTION
Fix issue where if the final piece of the import string wasn't capitalized, only one string would appear in the final RST. Which is fine as far as Java is concerned, but the sphinx RST compiler isn't happy about it.

For example, the following line of Java:

```
import package_a.package_b.package_c.lowercase_type_t;
```

would create the following RST:

```
.. java:import:: package_a.package_b.package_c.lowercase_type_t;
```

causing the following error:

```
ERROR: Error in "java:import" directive:
2 argument(s) required, 1 supplied.
```

This change appends the final piece as a class part, resulting in the following RST:

```
.. java:import:: package_a.package_b.package_c.lowercase_type_t lowercase_type_t;
```
