### PR TITLE
Feature/html converter options

### DIFF
--- a/javasphinx/apidoc.py
+++ b/javasphinx/apidoc.py
@@ -266,7 +266,7 @@ Note: By default this script will not overwrite already created files.""")
                       help='file suffix (default: rst)', default='rst')
     parser.add_option('-I', '--include', action='append', dest='includes',
                       help='Additional input paths to scan', default=[])
-    parser.add_option('-p', '--parser', action='parser_lib', default='lxml',
+    parser.add_option('-p', '--parser', dest='parser_lib', default='lxml',
                       help='Beautiful Soup---html parser library option.')
     parser.add_option('-v', '--verbose', action='store_true', dest='verbose',
                       help='verbose output')

--- a/javasphinx/apidoc.py
+++ b/javasphinx/apidoc.py
@@ -191,10 +191,10 @@ def generate_from_source_file(doc_compiler, source_file, cache_dir):
 
     return documents
 
-def generate_documents(source_files, cache_dir, verbose, member_headers):
+def generate_documents(source_files, cache_dir, verbose, member_headers, parser):
     documents = {}
     sources = {}
-    doc_compiler = compiler.JavadocRestCompiler(None, member_headers)
+    doc_compiler = compiler.JavadocRestCompiler(None, member_headers, parser)
 
     for source_file in source_files:
         if verbose:
@@ -266,6 +266,8 @@ Note: By default this script will not overwrite already created files.""")
                       help='file suffix (default: rst)', default='rst')
     parser.add_option('-I', '--include', action='append', dest='includes',
                       help='Additional input paths to scan', default=[])
+    parser.add_option('-p', '--parser', action='parser_lib', default='lxml',
+                      help='Beautiful Soup---html parser library option.')
     parser.add_option('-v', '--verbose', action='store_true', dest='verbose',
                       help='verbose output')
 
@@ -303,7 +305,7 @@ Note: By default this script will not overwrite already created files.""")
         source_files.extend(find_source_files(input_path, excludes))
 
     packages, documents, sources = generate_documents(source_files, opts.cache_dir, opts.verbose,
-                                                      opts.member_headers)
+                                                      opts.member_headers, opts.parser_lib)
 
     write_documents(documents, sources, opts)
 

--- a/javasphinx/compiler.py
+++ b/javasphinx/compiler.py
@@ -25,14 +25,14 @@ class JavadocRestCompiler(object):
     """ Javadoc to ReST compiler. Builds ReST documentation from a Java syntax
     tree. """
 
-    def __init__(self, filter=None, member_headers=True):
+    def __init__(self, filter=None, member_headers=True, parser='lxml'):
         if filter:
             self.filter = filter
         else:
             # Default, document all non-private members
             self.filter = lambda node: isinstance(node, javalang.tree.Declaration) and 'private' not in node.modifiers
 
-        self.converter = htmlrst.Converter()
+        self.converter = htmlrst.Converter(parser)
 
         self.member_headers = member_headers
 

--- a/javasphinx/htmlrst.py
+++ b/javasphinx/htmlrst.py
@@ -23,7 +23,7 @@ from bs4 import BeautifulSoup
 Cell = collections.namedtuple('Cell', ['type', 'rowspan', 'colspan', 'contents'])
 
 class Converter(object):
-    def __init__(self):
+    def __init__(self, parser):
         self._unknown_tags = set()
         self._clear = '\n\n..\n\n'
 
@@ -36,6 +36,7 @@ class Converter(object):
         self._html_tag = re.compile(r'<.*?>')
 
         self._preprocess_entity = re.compile(r'&(nbsp|lt|gt|amp)([^;]|[\n])')
+        self._parser = parser
 
     # --------------------------------------------------------------------------
     # ---- reST Utility Methods ----
@@ -402,7 +403,7 @@ class Converter(object):
         if not s_html.strip():
             return ''
 
-        soup = BeautifulSoup(s_html, 'lxml')
+        soup = BeautifulSoup(s_html, self._parser)
         top = soup.html.body
 
         result = self._process_children(top)


### PR DESCRIPTION
Hi,

I made a small change to the library by adding another command line option for specifying the html parser library that can be used. If none is specified then it uses the 'lxml' parser. There was a specific need for me to make javasphinx work with my other project which uses jython and jython had issues with 'lxml'. I thought this would be a good addition to the project, so i made it more configurable.

thanks,
bala