### PR TITLE
Fix import module not found

### DIFF
--- a/javasphinx/__init__.py
+++ b/javasphinx/__init__.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from .domain import JavaDomain
-from .extdoc import javadoc_role
+from javasphinx.domain import JavaDomain
+from javasphinx.extdoc import javadoc_role
 
 def setup(app):
     app.add_domain(JavaDomain)


### PR DESCRIPTION
Can we get a new release on pip with this patch? We'd like to use javasphinx with tox, but currently it's broken.