### PR TITLE
Without package declaration, a package named 'default package' is used.

### DIFF
--- a/javasphinx/compiler.py
+++ b/javasphinx/compiler.py
@@ -319,10 +319,7 @@ class JavadocRestCompiler(object):
             imports.append(util.Directive('java:import', package + ' ' + cls).build())
         import_block = imports.build()
 
-        if not ast.package:
-            raise ValueError('File must have package declaration')
-
-        package = ast.package.name
+        package = ast.package.name if ast.package else 'default package'
         type_declarations = []
         for path, node in ast.filter(javalang.tree.TypeDeclaration):
             if not self.filter(node):


### PR DESCRIPTION
This avoids ValueError when parsing Java files without package declaration.

test:

```
from javasphinx.apidoc import main as parse
parse(['', '-v', '-o', 'test_apidoc', 'test_project/src/test/java'])

from os import listdir
listdir('./test_apidoc')
> ['default package', 'packages.rst']
```

ref. [PR on Javalang](https://github.com/c2nes/javalang/pull/32)
