### PR TITLE
Closes #12

### DIFF
--- a/javasphinx/apidoc.py
+++ b/javasphinx/apidoc.py
@@ -201,11 +201,9 @@ def generate_from_source_file(doc_compiler, source_file, cache_dir):
     documents = {}
     try:
         if source_file.endswith("package-info.java"):
-            for node in dict(ast).values():
-                if isinstance(node, javalang.tree.PackageDeclaration):
-                    documentation = doc_compiler.compile_docblock(node)
-                    documents[node.name] = (node.name, 'package-info', documentation)
-                    break
+            if ast.package is not None:
+                documentation = doc_compiler.compile_docblock(ast.package)
+                documents[ast.package.name] = (ast.package.name, 'package-info', documentation)
         else:
             documents = doc_compiler.compile(ast)
     except Exception:

--- a/javasphinx/apidoc.py
+++ b/javasphinx/apidoc.py
@@ -15,6 +15,7 @@
 #
 
 from __future__ import print_function, unicode_literals
+import re 
 
 try:
    import cPickle as pickle
@@ -69,10 +70,9 @@ def write_toc(packages, opts):
     toc.add_option('maxdepth', '2')
     doc.add_object(toc)
 
-    packages = list(packages)
-    packages.sort()
-    for package in packages:
-        toc.add_content(package.replace('.', '/') + '/package-index\n')
+    sorted_packages = sorted(packages.items(), key=lambda x: x[0])
+    for package, _ in sorted_packages:
+        toc.add_content("%s/package-index\n" % package.replace('.', '/'))
 
     filename = 'packages.' + opts.suffix
     fullpath = os.path.join(opts.destdir, filename)
@@ -85,11 +85,14 @@ def write_toc(packages, opts):
     f.write(encode_output(doc.build()))
     f.close()
 
-def write_documents(documents, sources, opts):
+def write_documents(packages, documents, sources, opts):
     package_contents = dict()
 
     # Write individual documents
     for fullname, (package, name, document) in documents.items():
+        if is_package_info_doc(package, name):
+            continue
+
         package_path = package.replace('.', os.sep)
         filebasename = name.replace('.', '-')
         filename = filebasename + '.' + opts.suffix
@@ -119,19 +122,24 @@ def write_documents(documents, sources, opts):
         f.close()
 
     # Write package-index for each package
-    for package, index in package_contents.items():
+    for package, classes in package_contents.items():
         doc = util.Document()
         doc.add_heading(package, '=')
+
+        #Adds the package documentation (if any)
+        if packages[package] != '':
+            documentation = packages[package]
+            doc.add_line("\n%s" % documentation)
 
         doc.add_object(util.Directive('java:package', package))
 
         toc = util.Directive('toctree')
         toc.add_option('maxdepth', '1')
-        doc.add_object(toc)
 
-        index.sort()
-        for filebasename in index:
+        classes.sort()
+        for filebasename in classes:
             toc.add_content(filebasename + '\n')
+        doc.add_object(toc)
 
         package_path = package.replace('.', os.sep)
         filename = 'package-index.' + opts.suffix
@@ -192,8 +200,14 @@ def generate_from_source_file(doc_compiler, source_file, cache_dir):
     except Exception:
         util.unexpected('Unexpected exception while parsing %s', source_file)
 
+    documents = {}
     try:
-        documents = doc_compiler.compile(ast)
+        if source_file.endswith("package-info.java"):
+            for _, node in ast.filter(javalang.tree.PackageDeclaration):
+                document = doc_compiler.compile_package_documentation(node)
+                documents[node.name] = (node.name, node.name, document.build())
+        else:
+            documents = doc_compiler.compile(ast)
     except Exception:
         util.unexpected('Unexpected exception while compiling %s', source_file)
 
@@ -214,16 +228,26 @@ def generate_documents(source_files, cache_dir, verbose, member_headers, parser)
             print('Processing', source_file)
 
         this_file_documents = generate_from_source_file(doc_compiler, source_file, cache_dir)
-
         for fullname in this_file_documents:
             sources[fullname] = source_file
 
         documents.update(this_file_documents)
 
-    packages = set()
 
+    #Existing packages dict, where each key is a package name
+    #and each value is the package documentation (if any)
+    packages = {}
+
+    #Gets the name of the package where the document was declared
+    #and adds it to the packages dict with no documentation.
+    #Package documentation, if any, will be collected from package-info.java files.
     for package, _, _ in documents.values():
-        packages.add(package)
+        packages[package] = ""
+
+    #Gets packages documentation from package-info.java (if any).
+    for package, name, content in documents.values():
+        if is_package_info_doc(package, name):
+            packages[name] = content
 
     return packages, documents, sources
 
@@ -243,6 +267,11 @@ def is_excluded(root, excludes):
         if root.startswith(exclude):
             return True
     return False
+
+def is_package_info_doc(package_name, document_name):
+    #if the object's package name is equal to the object name, the object is a package
+    return package_name == document_name
+
 
 def main(argv=sys.argv):
     logging.basicConfig(level=logging.WARN)
@@ -320,7 +349,7 @@ Note: By default this script will not overwrite already created files.""")
     packages, documents, sources = generate_documents(source_files, opts.cache_dir, opts.verbose,
                                                       opts.member_headers, opts.parser_lib)
 
-    write_documents(documents, sources, opts)
+    write_documents(packages, documents, sources, opts)
 
     if not opts.notoc:
         write_toc(packages, opts)

--- a/javasphinx/compiler.py
+++ b/javasphinx/compiler.py
@@ -43,7 +43,7 @@ class JavadocRestCompiler(object):
         if not isinstance(node, javalang.tree.Declaration):
             return False
 
-        if node.modifiers is not None and 'private' in node.modifiers:
+        if 'private' in node.modifiers:
             return False
 
         if isinstance(node, javalang.tree.Documented) and node.documentation:
@@ -115,14 +115,6 @@ class JavadocRestCompiler(object):
         directive.add_content(doc)
 
         return directive
-
-    def compile_package_documentation(self, declaration):
-        signature = util.StringBuilder()
-        formatter.output_declaration(declaration, declaration.name)
-
-        doc = self.__output_doc(declaration)
-
-        return doc
 
     def compile_enum_constant(self, enum, constant):
         signature = util.StringBuilder()
@@ -349,3 +341,7 @@ class JavadocRestCompiler(object):
 
 
         return documents
+
+    def compile_docblock(self, documented):
+        ''' Compiles a single, standalone docblock. '''
+        return self.__output_doc(documented).build()

--- a/javasphinx/compiler.py
+++ b/javasphinx/compiler.py
@@ -338,8 +338,6 @@ class JavadocRestCompiler(object):
             full_name = package + '.' + name
             document = self.compile_type_document(import_block, package, name, declaration)
             documents[full_name] = (package, name, document.build())
-
-
         return documents
 
     def compile_docblock(self, documented):

--- a/javasphinx/compiler.py
+++ b/javasphinx/compiler.py
@@ -15,7 +15,6 @@
 #
 
 import javalang
-import re
 
 import javasphinx.formatter as formatter
 import javasphinx.util as util
@@ -40,10 +39,11 @@ class JavadocRestCompiler(object):
         docblocks.
 
         """
+
         if not isinstance(node, javalang.tree.Declaration):
             return False
 
-        if 'private' in node.modifiers:
+        if node.modifiers is not None and 'private' in node.modifiers:
             return False
 
         if isinstance(node, javalang.tree.Documented) and node.documentation:
@@ -115,6 +115,14 @@ class JavadocRestCompiler(object):
         directive.add_content(doc)
 
         return directive
+
+    def compile_package_documentation(self, declaration):
+        signature = util.StringBuilder()
+        formatter.output_declaration(declaration, declaration.name)
+
+        doc = self.__output_doc(declaration)
+
+        return doc
 
     def compile_enum_constant(self, enum, constant):
         signature = util.StringBuilder()
@@ -338,5 +346,6 @@ class JavadocRestCompiler(object):
             full_name = package + '.' + name
             document = self.compile_type_document(import_block, package, name, declaration)
             documents[full_name] = (package, name, document.build())
+
 
         return documents

--- a/javasphinx/formatter.py
+++ b/javasphinx/formatter.py
@@ -115,9 +115,6 @@ def output_type_params(type_params, output):
 
 @formatter
 def output_declaration(declaration, output):
-    if declaration.annotations is None:
-        return
-
     for annotation in declaration.annotations:
         output_annotation(annotation, output)
 

--- a/javasphinx/formatter.py
+++ b/javasphinx/formatter.py
@@ -115,6 +115,9 @@ def output_type_params(type_params, output):
 
 @formatter
 def output_declaration(declaration, output):
+    if declaration.annotations is None:
+        return
+
     for annotation in declaration.annotations:
         output_annotation(annotation, output)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 setup(
     name = "javasphinx",
     packages = ["javasphinx"],
-    version = "0.9.14",
+    version = "0.9.15",
     author = "Chris Thunes",
     author_email = "cthunes@brewtab.com",
     url = "http://github.com/bronto/javasphinx",


### PR DESCRIPTION
Added support to read package-info.java files and load package documentation
to insert into the generated package-index files.

Now the list of packages returned by the method generate_documents
from apidoc.py returns a dictionary instead of list containing just
the package names.

That dictionary uses the package name as a key
and each value is a a tuple in the same format used
for the documents dict returned by that same method.

Such a tuple contains 3 values: (package_name, class_name, parsed_javadoc).
For the elements of the packages dict, the only difference is that
instead of the class_name, it is repeated the package name.